### PR TITLE
Py3 parser fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup, find_packages
 
 setup(name='wreports',
-      version='1.2.3',
+      version='1.2.4',
       author='Matteo Bertini <naufraghi@develer.com>',
-      description='Fixed page report generator',
+      description='Introduced Python3 support',
       long_description=open('README.rst').read(),
       license='LICENSE.txt',
       keywords="qt, report",

--- a/src/wreports/parser.py
+++ b/src/wreports/parser.py
@@ -3,7 +3,7 @@
 from __future__ import print_function, absolute_import, division
 
 import xml.parsers.expat
-import types
+import sys
 import os
 import textwrap
 
@@ -25,6 +25,12 @@ except ImportError:
     from PyQt4.QtSvg import QSvgWidget
 
 from . import errors
+
+PY3 = sys.version_info.major == 3
+if PY3:
+    string_types = (str, bytes)
+else:
+    from types import StringTypes as string_types
 
 __all__ = ["parse"]
 
@@ -559,7 +565,7 @@ class QTextEditRenderer(mistune.Renderer):
 
 def parse(source, env=None):
     p = xml.parsers.expat.ParserCreate()
-    if isinstance(source, types.StringTypes):
+    if isinstance(source, string_types):
         _parse = p.Parse
     else:
         _parse = p.ParseFile


### PR DESCRIPTION
Use `(str, bytes)` as `isinstance` argument in Python3, keeping the behaviour unchanged and preventing the crash.